### PR TITLE
Use the clutter embed instead of the window as size reference

### DIFF
--- a/FinalTerm.vala
+++ b/FinalTerm.vala
@@ -75,11 +75,10 @@ public class FinalTerm : Gtk.Application, ColorSchemable, Themable {
 		main_window.resizable = true;
 		main_window.has_resize_grip = true;
 
-		main_window.configure_event.connect(on_configure_event);
-
 		// TODO: Send configure event to ensure correct wrapping + rendering?
 
 		clutter_embed = new GtkClutter.Embed();
+		clutter_embed.configure_event.connect(on_configure_event);
 		clutter_embed.show();
 		main_window.add(clutter_embed);
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ VALA_OPTIONS = \
 	--pkg posix \
 	--pkg linux \
 	--pkg gee-0.8 \
-	--pkg keybinder
+	--pkg keybinder-3.0
 
 default:
 	$(VALA_COMPILER) $(VALA_OPTIONS) -o $(OUTPUT_FILE) $(SOURCE_FILES)


### PR DESCRIPTION
Using the clutter embed as size reference is more reliable, as not all window managers support hiding the menubar. The TerminalView will otherwise always be a couple of pixels too tall.

I also had to make sure keybinder-3.0 is requested, otherwise it would fail running as it mixes Gtk+-2 and 3 elements, not sure how you got it to run. (Valac-0.18 on Ubuntu 13.04 here)
