### PR TITLE
Not possible to run shell as if it were a login shell

### DIFF
--- a/data/org.gnome.finalterm.gschema.xml
+++ b/data/org.gnome.finalterm.gschema.xml
@@ -46,6 +46,11 @@
 			<summary>Path to the shell executable which is to be run (NOTE: Only bash is currently supported)</summary>
 			<description></description>
 		</key>
+		<key type="as" name="shell-arguments">
+			<default>[]</default>
+			<summary>Options to pass to the shell executable</summary>
+			<description></description>
+		</key>
 		<key type="s" name="emulated-terminal">
 			<default>'xterm-256color'</default>
 			<summary>Value that the TERM environment variable will be set to (NOTE: Changing this variable may affect shell behavior)</summary>

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -120,6 +120,11 @@ public class Settings : Object {
 		set { settings.set_string("shell-path", value); }
 	}
 
+	public string[] shell_arguments {
+		owned get { return settings.get_strv("shell-arguments"); }
+		set { settings.set_strv("shell-arguments", value); }
+	}
+
 	public string emulated_terminal {
 		owned get { return settings.get_string("emulated-terminal"); }
 		set { settings.set_string("emulated-terminal", value); }

--- a/src/Terminal.vala
+++ b/src/Terminal.vala
@@ -222,9 +222,14 @@ public class Terminal : Object {
 	private void run_shell() {
 		Environment.set_variable("TERM", Settings.get_default().emulated_terminal, true);
 
+		// Add custom shell arguments
+		string[] arguments = { Settings.get_default().shell_path, "--rcfile", Config.PKGDATADIR + "/Startup/bash_startup", "-i" };
+		foreach (var argument in Settings.get_default().shell_arguments) {
+			arguments += argument;
+		}
+
 		// Replace child process with shell process
-		Posix.execvp(Settings.get_default().shell_path,
-				{ Settings.get_default().shell_path, "--rcfile", Config.PKGDATADIR + "/Startup/bash_startup", "-i" });
+		Posix.execvp(Settings.get_default().shell_path, arguments);
 
 		// If this line is reached, execvp() must have failed
 		critical(_("execvp failed"));


### PR DESCRIPTION
I'd like to pass custom options to my shell, but I can't since no configuration option is available in `dconf` for it. Could a `shell-options` option be added? It looks as though `run_shell` would need amending:

https://github.com/p-e-w/finalterm/blob/master/src/Terminal.vala#L222-L232
