### PR TITLE
CMake: configure_file use @ONLY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,13 @@ set(PKGDATADIR "${DATADIR}/finalterm")
 set(VERSION 0.1)
 set(GETTEXT_PACKAGE "finalterm")
 set(LOCALE_DIR "${DATADIR}/locale")
-set(DOLLAR "$")
 set(VALAFLAGS "")
 if (NOT MINIMAL_FLAGS)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb")
 endif (NOT MINIMAL_FLAGS)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/Config.vala.cmake ${CMAKE_BINARY_DIR}/src/Config.vala)
-configure_file(${CMAKE_SOURCE_DIR}/data/Startup/bash_startup ${CMAKE_BINARY_DIR}/Startup/bash_startup)
+configure_file(${CMAKE_SOURCE_DIR}/data/Startup/bash_startup ${CMAKE_BINARY_DIR}/Startup/bash_startup @ONLY)
 
 set(PKGS clutter-gtk-1.0 mx-1.0 keybinder-3.0)
 

--- a/data/Startup/bash_startup
+++ b/data/Startup/bash_startup
@@ -16,10 +16,7 @@ function final_term_control_sequence() {
 		control_sequence="$control_sequence$argument;"
 	done
 	# TODO: Remove last semicolon
-	# this DOLLAR is required for the cmake configure_file
-	# when using a $ it'd try to replace the control_sequence
-	# with one of its own variables and thus remove it
-	control_sequence="${DOLLAR}{control_sequence}\a"
+	control_sequence="$control_sequence\a"
 
 	# TODO: Should "-ne" be added here?
 	echo "$control_sequence"


### PR DESCRIPTION
Don't replace `${foobar}` strings which are valid expressions in some shell
files. Only replace `@foobar@` occurrences.

I have additionally removed the curly brackets from "${control_sequence}\a" but this should work with sh shells.
