### PR TITLE
Make the menu button transparent instead of hiding it (Fixes #30)

### DIFF
--- a/src/TerminalView.vala
+++ b/src/TerminalView.vala
@@ -179,9 +179,13 @@ public class TerminalOutputView : Mx.ScrollView {
 		menu_button = new Mx.Button();
 		menu_button.is_toggle = true;
 		menu_button.style_class = "menu-button";
+		menu_button.enter_event.connect((event) => {
+			menu_button.opacity = 255;
+			return false;
+		});
 		menu_button.leave_event.connect((event) => {
 			if (!menu_button.toggled)
-				menu_button.visible = false;
+				menu_button.opacity = 0;
 			return false;
 		});
 		menu_button.clicked.connect(on_menu_button_clicked);


### PR DESCRIPTION
This way it will still recieves the events, and the (visible) behaviour is unchanged.
Since the button won't react to keyboard, the only way to interact with it is the
mouse and it will appear when the mouse is over it.
