### PR TITLE
Quote arguments in termlets, fixing #165

### DIFF
--- a/data/Termlets/ls
+++ b/data/Termlets/ls
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ls_output=$(ls --color=always $@)
+ls_output=$(ls --color=always "$@")
 
 # TODO: Search for files in directory passed to ls rather than the current directory
 # TODO: Handle case where filename contains other filename

--- a/data/Termlets/ps
+++ b/data/Termlets/ps
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ps $@ |
+ps "$@" |
 
 while IFS= read -r line; do
 	# Position of string "PID" in line

--- a/data/Termlets/wget
+++ b/data/Termlets/wget
@@ -3,7 +3,7 @@
 # TODO: Multiple file downloads?
 
 # Note that wget writes its output to STDERR instead of STDOUT
-wget --progress=bar:force $@ 2>&1 |
+wget --progress=bar:force "$@" 2>&1 |
 
 while IFS= read -r line; do
 	echo "$line"


### PR DESCRIPTION
This trivial fix should fix those quoting related issues with termlet arguments.
