### PR TITLE
Remove deprecated OnlyShowIn from desktop action

### DIFF
--- a/data/finalterm.desktop.in
+++ b/data/finalterm.desktop.in
@@ -12,4 +12,3 @@ Actions=NewWindow;
 [Desktop Action NewWindow]
 _Name=Open a New Window
 Exec=finalterm
-OnlyShowIn=Unity;


### PR DESCRIPTION
Support for OnlyShowIn in Action groups has been removed from the
desktop entry specification according to [upstream bug](https://bugs.freedesktop.org/show_bug.cgi?id=66712). Starting
with version 0.22, desktop-file-validate warns about it asking for a
little bit of QA love.
