### PR TITLE
Tell CMake this is a C project to prevent checks for a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(finalterm)
+project(finalterm C)
 cmake_minimum_required(VERSION 2.8)
 cmake_policy(VERSION 2.6)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
I can't find the issue, if there was one created for it, but I saw somewhere someone was complaining they don't have g++ installed only gcc and could not compile FinalTerm because CMake forced them to have g++. This should fix that.
