### PR TITLE
only source ~/.bashrc if it exists

### DIFF
--- a/data/Startup/bash_startup.in
+++ b/data/Startup/bash_startup.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Include default startup file so that user's settings are respected
-source ~/.bashrc
+[[ -r ~/.bashrc ]] && source ~/.bashrc
 
 
 


### PR DESCRIPTION
I don't want to see this error on start up.

```
bash: /home/carl/.bashrc: No such file or directory
```
