### PR TITLE
Improve data directory handling

### DIFF
--- a/src/FinalTerm.vala
+++ b/src/FinalTerm.vala
@@ -416,7 +416,7 @@ public class FinalTerm : Gtk.Application {
 		var data_dir = File.new_for_path(Environment.get_user_data_dir() + "/finalterm");
 		if (!data_dir.query_exists()) {
 			try {
-				data_dir.make_directory();
+				data_dir.make_directory_with_parents();
 			} catch (Error e) { error(_("Cannot access data directory %s: %s"), data_dir.get_parse_name(), e.message); }
 		}
 


### PR DESCRIPTION
FinalTerm tries to create its data directory it it doesn't exists. But since it currently ony tries to call `make_directory()`, it will fail if any of the parent directories above the data directory are non-existing as well.

This pull request tries to resolve that problem by using `make_directory_with_parents()` instead (fixes #226), and it also makes the error output more verbose to let the user know which directory's handling was problematic.

@p-e-w: please review those changes, and let me know if I need to update them in any way :)
