### PR TITLE
Update URL matching pattern (fix #204)

### DIFF
--- a/data/TextMenus/url.ftmenu
+++ b/data/TextMenus/url.ftmenu
@@ -2,8 +2,8 @@
 
 marker-type = pattern
 
-# Web URL regular expression taken from http://regexlib.com/REDetails.aspx?regexp_id=1051 (modified)
-pattern = \b((http\://|https\://|ftp\://)|(www.))+([a-zA-Z0-9\.-]+\.[a-zA-Z]{2,4})(/[a-zA-Z0-9%&:/-_\?\.'~]*)?\b
+# Web URL regular expression taken from https://github.com/muennich/urxvt-perls/blob/master/url-select (collapsed into one line)
+pattern = \b(?:https?://|ftp://|news://|mailto:|file://|\bwww\.)[\w\-\@;\/?:&=%\$.+!*\x27,~#]*(\([\w\-\@;\/?:&=%\$.+!*\x27,~#]*\)|[\w\-\@;\/?:&=%\$+*~])+\b
 
 label = URL
 color = 6


### PR DESCRIPTION
This fine pattern is originally from Bert Münnich's url-select extension
for the rxvt-unicode terminal emulator, from his urxvt-perls project.

This fixes both the port number highlighting and the '`-` as URL path element' issues reported on #204 (and possibly other similar cases).
