### PR TITLE
Add the HVP control sequence, handle it identically as the CUP control sequence

### DIFF
--- a/src/TerminalOutput.vala
+++ b/src/TerminalOutput.vala
@@ -327,6 +327,7 @@ public class TerminalOutput : Gee.ArrayList<OutputLine> {
 						cursor_position.column + stream_element.get_numeric_parameter(0, 1));
 				break;
 
+			case TerminalStream.StreamElement.ControlSequenceType.HORIZONTAL_AND_VERTICAL_POSITION:
 			case TerminalStream.StreamElement.ControlSequenceType.CURSOR_POSITION:
 				int line   = stream_element.get_numeric_parameter(0, 1);
 				int column = stream_element.get_numeric_parameter(1, 1);


### PR DESCRIPTION
Some applications (the Testem JavaScript testing famework) use HVP control sequence to initiate redraws of the interface. By supporting them, we can make testem and more be rendered correctly.

The HVP CS can be handled identically to the CUP control sequence:
http://www.vt100.net/docs/vt100-ug/chapter3.html
