### PR TITLE
To swap 'split' labels

### DIFF
--- a/src/TerminalWidget.vala
+++ b/src/TerminalWidget.vala
@@ -156,13 +156,13 @@ public class TerminalWidget : GtkClutter.Embed, NestingContainerChild {
 
 		context_menu.append(new Gtk.SeparatorMenuItem());
 
-		menu_item = new Gtk.MenuItem.with_label(_("Split Horizontally"));
+		menu_item = new Gtk.MenuItem.with_label(_("Split Vertically"));
 		menu_item.activate.connect(() => {
 			split(Gtk.Orientation.HORIZONTAL);
 		});
 		context_menu.append(menu_item);
 
-		menu_item = new Gtk.MenuItem.with_label(_("Split Vertically"));
+		menu_item = new Gtk.MenuItem.with_label(_("Split Horizontally"));
 		menu_item.activate.connect(() => {
 			split(Gtk.Orientation.VERTICAL);
 		});


### PR DESCRIPTION
### To swap 'split' labels

This will make it more intuitive for users.
- **Split Horizontally** should add **horizontal** divider (split). _This makes this two vertical GTK controls._
- **Split Vertically** should add **vertical** divider (split). _This makes this two horizontal GTK controls._

---

Here are examples from other terminal emulators:
- Terminator:
  ![terminator_split](https://cloud.githubusercontent.com/assets/7157049/3558908/848dd848-0942-11e4-9256-9986e99e5d25.png)
- Terminology:
  ![terminology_split](https://cloud.githubusercontent.com/assets/7157049/3558909/848df2e2-0942-11e4-88b9-1bf2efa03fe9.png)
