### PR TITLE
Escape filenames for semantic menu commands

### DIFF
--- a/src/Terminal.vala
+++ b/src/Terminal.vala
@@ -83,11 +83,11 @@ public class Terminal : Object {
 
 	public void set_command(string command) {
 		clear_command();
-		send_text(command);
+		send_text(/(?<!\\)\'/.replace(command, -1, 0, ""));
 	}
 
 	public void run_command(string command) {
-		set_command(command);
+		set_command(/(?<!\\)\'/.replace(command, -1, 0, ""));
 		send_text("\n");
 	}
 

--- a/src/TextMenu.vala
+++ b/src/TextMenu.vala
@@ -39,6 +39,18 @@ public class TextMenu : Object {
 
 	public string text { get; set; }
 
+	public string escape_parameters(string s) {
+		var escape_characters = new string[] {" ", "&", "'", ";", "#", "\"", "`", "|", "*", "?", "$", "<", ">", "(", ")", "~"};
+		var backslash = "\\";
+		string temp = s;
+		
+		foreach(var character in escape_characters) 
+			temp = temp.replace(character, backslash.concat(character) );
+
+		return temp;
+	}
+
+
 	public TextMenu.load_from_file(string filename) {
 		var menu_file = new KeyFile();
 		try {
@@ -76,7 +88,7 @@ public class TextMenu : Object {
 
 					menu_item.activate.connect(() => {
 						var placeholder_substitutes = new Gee.ArrayList<string>();
-						placeholder_substitutes.add(text);
+						placeholder_substitutes.add(escape_parameters(text));
 						foreach (var command in commands) {
 							command.execute(placeholder_substitutes);
 						}


### PR DESCRIPTION
Fixes #266 by escaping filenames so that they can be properly used by tools listed in the semantic menu.
The incorporated special characters are located here:
http://www.tldp.org/LDP/abs/html/special-chars.html
