### PR TITLE
Fix escaping of single quotes in file menu

### DIFF
--- a/src/FinalTerm.vala
+++ b/src/FinalTerm.vala
@@ -271,13 +271,16 @@ public class FinalTerm : Gtk.Application {
 		case Command.CommandType.SET_SHELL_COMMAND:
 			if (command.parameters.is_empty)
 				return;
-			active_terminal_widget.set_shell_command(command.parameters.get(0));
+			active_terminal_widget.set_shell_command(Utilities.escape_shell_command(
+												     command.parameters.get(0)));
 			return;
 
 		case Command.CommandType.RUN_SHELL_COMMAND:
 			if (command.parameters.is_empty)
 				return;
-			active_terminal_widget.run_shell_command(command.parameters.get(0));
+
+			active_terminal_widget.run_shell_command(Utilities.escape_shell_command(
+													 command.parameters.get(0)));
 			return;
 
 		case Command.CommandType.TOGGLE_VISIBLE:

--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -215,4 +215,23 @@ public class Utilities : Object {
 		}, priority);
 	}
 
+	// Escapes single quotes in a shell command, used for the tools in the semantic
+	// menus (cat/less/cp/mv/stat)
+	public static string escape_shell_command(string rawCommand) {
+		StringBuilder escapedString = new StringBuilder();
+
+		for (int i = 0; i < rawCommand.length - 1; i++) {
+				if (rawCommand[i] == '\'' && rawCommand.index_of("\'") != i) {
+					escapedString.append("\'\\'\'");
+				}
+
+				else {
+					escapedString.append_unichar(rawCommand[i]);
+				}
+			}
+
+			escapedString.append_unichar('\'');
+
+			return escapedString.str;
+	}
 }


### PR DESCRIPTION
Fixes #266 by adding a function to utilities that will replace
all occurences of a single quote with '\'' except for the first
and last ones. This function is then called before setting/running
the shell command from the semantic menu.
