### PR TITLE
Escape filenames for use with semantic menu commands

### DIFF
--- a/src/TextMenu.vala
+++ b/src/TextMenu.vala
@@ -39,6 +39,11 @@ public class TextMenu : Object {
 
 	public string text { get; set; }
 
+	public string escape_parameters(string s) {
+		return s.replace("'", "'\\''");;
+	}
+
+
 	public TextMenu.load_from_file(string filename) {
 		var menu_file = new KeyFile();
 		try {
@@ -76,7 +81,7 @@ public class TextMenu : Object {
 
 					menu_item.activate.connect(() => {
 						var placeholder_substitutes = new Gee.ArrayList<string>();
-						placeholder_substitutes.add(text);
+						placeholder_substitutes.add(escape_parameters(text));
 						foreach (var command in commands) {
 							command.execute(placeholder_substitutes);
 						}


### PR DESCRIPTION
Fixes #266 by escaping filenames with quotes so that they can be properly used by tools listed in the semantic menu.
This approach (as opposed to that found in a0def85875f8625aedcb50c19a83094955c098e0) is better for readability and for use with the clipboard if a group of text is selected and then copied.
