### PR TITLE
Fix #338

### DIFF
--- a/data/Termlets/ls
+++ b/data/Termlets/ls
@@ -10,6 +10,7 @@ file_end_mark=$(text_menu_end '1')
 ls_output=$'\n'$ls_output$'\n'
 
 # TODO: Search for files in directory passed to ls rather than the current directory
+shopt -s nullglob dotglob
 for filename in *; do
 	if [[ -d $filename ]]; then
 		file_substitution="$dir_begin_mark$filename$dir_end_mark"


### PR DESCRIPTION
Fixes #338 by including hidden files in `ls -a` output. Thanks to Carnassial for this fix.
